### PR TITLE
Containernet example fails

### DIFF
--- a/containernet/net.py
+++ b/containernet/net.py
@@ -312,9 +312,9 @@ class Containernet( Mininet_wifi ):
         node2 = node2 if not isinstance(node2, string_types) else self[node2]
         options = dict(params)
 
-        self.conn.setdefault('src', [])
-        self.conn.setdefault('dst', [])
-        self.conn.setdefault('ls', [])
+        options.setdefault('src', [])
+        options.setdefault('dst', [])
+        options.setdefault('ls', [])
 
         cls = self.link if cls is None else cls
 
@@ -328,9 +328,9 @@ class Containernet( Mininet_wifi ):
             return link
         elif cls == _4address:
             if 'position' in node1.params and 'position' in node2.params:
-                self.conn['src'].append(node1)
-                self.conn['dst'].append(node2)
-                self.conn['ls'].append('--')
+                options['src'].append(node1)
+                options['dst'].append(node2)
+                options['ls'].append('--')
 
             if node1 not in self.aps:
                 self.aps.append(node1)
@@ -358,9 +358,9 @@ class Containernet( Mininet_wifi ):
                 options.pop('link', None)
 
             if 'position' in node1.params and 'position' in node2.params:
-                self.conn['src'].append(node1)
-                self.conn['dst'].append(node2)
-                self.conn['ls'].append('-')
+                options['src'].append(node1)
+                options['dst'].append(node2)
+                options['ls'].append('-')
             # Port is optional
             if port1 is not None:
                 options.setdefault('port1', port1)


### PR DESCRIPTION
The containernet_example.py example can't be run because there's a bug in the addLink method of net.py. The self.conn is not defined, but substituting it by options fixes the issue and the example works.